### PR TITLE
fix: change api url and request to fix sending a live signal

### DIFF
--- a/config_live.py
+++ b/config_live.py
@@ -4,7 +4,7 @@ bot_name = 'rsi'
 # Datasource is poloniex or cryptocompare
 datasource = 'poloniex'
 
-revenyou_api_url = 'https://youhex.revenyou.io/api/signal/v1/signal'
+revenyou_api_url = 'https://youhexpaper.revenyou.io/api/signal/v1/signal'
 
 # Data settings real time data poloniex
 data_settings_poloniex = {
@@ -24,9 +24,12 @@ buy_signal_settings = {
     'signal_provider': '[NAME OF BOT]',
     'signal_provider_key': '[KEY]',
     'exchange': datasource,
-    'symbol': 'BTCETH', # Must be in line with the data settings object pair value!  
+    'symbol': 'BTC_ETH', # Must be in line with the data settings object pair value!  
     'price_limit': '100', # Buy BTC with a price limit of 100 ETH
     'buy_ttl_sec': 1800, # Time (in seconds) for buy order to live
-    'take_profit_price_percentage': '10', # Take profit when price of BTC goes up with 10%
-    'stop_loss_price_percentage': '5' # Close position (stop loss) when price of BTC  goes down with 5%
+    'take_profit_price_percentage_60': '5', # Take 60% profit when price of BTC goes up with 5%
+    'take_profit_price_percentage_40': '10', # Take 40% profit when price of BTC goes up with 10%
+    'stop_loss_price_percentage': '5', # Close position (stop loss) when price of BTC  goes down with 5%
+    'panic_sell_price_percentage': '20',
+    "panic_sell_price_deviation_percentage": '2'
 }

--- a/run_live.py
+++ b/run_live.py
@@ -17,7 +17,7 @@ def run_bot(data):
     # for now the revenyou api accepts only buy signals!
     if buy_or_sell_signal == 'buy':
         revenyou_api_signal = create_revenyou_buy_signal()
-        request = requests.post(url = revenyou_api_url.strip("\n"), data = revenyou_api_signal, headers = {'content-type': 'application/json'})
+        request = requests.post(url = revenyou_api_url.strip("\n"), json = revenyou_api_signal, headers = {'content-type': 'application/json'})
         print(request.json())
 
 def create_revenyou_buy_signal():
@@ -32,12 +32,20 @@ def create_revenyou_buy_signal():
         'buyTTLSec': buy_signal_settings.get('buy_ttl_sec'),
         'takeProfit': [
             {
-                'amountPercentage': '100',
-                'pricePercentage': buy_signal_settings.get('take_profit_price_percentage')
+                'amountPercentage': '60',
+                'pricePercentage': buy_signal_settings.get('take_profit_price_percentage_60')
+            },
+            {
+                'amountPercentage': '40',
+                'pricePercentage': buy_signal_settings.get('take_profit_price_percentage_40')
             }
         ],
         'stopLoss': {
             'pricePercentage': buy_signal_settings.get('stop_loss_price_percentage')
+        },
+        'panicSell': {
+            'pricePercentage': buy_signal_settings.get('panic_sell_price_percentage'),
+            'sellPriceDeviationPercentage': buy_signal_settings.get('panic_sell_price_deviation_percentage')
         }
     }
 


### PR DESCRIPTION
Changed the api url and use the json parameter instead of the data parameter in the POST request. With the right botname and key it is no possible to successful send a buy signal to the revenyou api.