### PR TITLE
Bug/issue 8 docker talib bug

### DIFF
--- a/docker/bot/Dockerfile
+++ b/docker/bot/Dockerfile
@@ -54,6 +54,7 @@ RUN chown -R bot /opt/bot
 # Run as user "bot"
 USER bot
 
+# Dynamic loader looks for shared libraries (like talib) in /usr/local/lib
 ENV LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
 
 # Run in test mode by default. Can be overridden from command line or docker-compose file to run in production mode.


### PR DESCRIPTION
Bugfix for running a bot with the talib library. Fixed it by adding the LD_LIBRARY_PATH env variable to the Dockerfile. Python will now look in the /usr/local/lib directory for shared files like talib.