### PR TITLE
Rb 23 mutitrade live poloniex and binance

### DIFF
--- a/api_service.py
+++ b/api_service.py
@@ -1,13 +1,17 @@
 import uuid
 import requests
+import logging
+from datetime import datetime
 
 from config_live import buy_signal_settings, revenyou_api_url
+
+logger = logging.getLogger(__name__)
 
 def send_request(pair):
     revenyou_api_signal = create_revenyou_buy_signal(pair=pair)
     response = requests.post(url = revenyou_api_url.strip("\n"), json = revenyou_api_signal, headers = {'content-type': 'application/json'})
 
-    print('response revenyou api on buy signal for pair {}: {}'.format(pair, response.json()))
+    logger.info('{}: response revenyou api on buy signal for pair {}: {}'.format(datetime.now(), pair, response.json()))
 
 def create_revenyou_buy_signal(pair):
     api_signal = {    

--- a/data/websocket_binance.py
+++ b/data/websocket_binance.py
@@ -1,9 +1,12 @@
 import websocket
 import json
 import pandas as pd
+import logging
 
 from config_live import data_settings_binance
 from api_service import send_request
+
+logger = logging.getLogger(__name__)
 
 class BinanceWebsocketClient:
     
@@ -45,15 +48,16 @@ class BinanceWebsocketClient:
 
     def run_bot(self, pair):
         ticker_data_list= self.pair_ticker_data_list_dictionary[pair]
-        df = self.createDataFrame(ticker_data_list=ticker_data_list)
+        df = self.create_dataframe(ticker_data_list=ticker_data_list)
         buy_or_sell_signal = self.get_buy_or_sell_signal(data=df)
-        print('buy signal for pair {}: {}'.format(pair, buy_or_sell_signal))
+        logger.debug('buy signal for pair {}: {}'.format(pair, buy_or_sell_signal))
+
 
         # for now the revenyou api accepts only buy signals!
         if buy_or_sell_signal == 'buy':
             send_request(pair=pair)
 
-    def createDataFrame(self, ticker_data_list):
+    def create_dataframe(self, ticker_data_list):
         df = pd.DataFrame(ticker_data_list)
         df.columns = ['type', 'date', 'symbol', 'close', 'open', 'high', 'low', 'volume', 'volume_quote']
         df['date'] = pd.to_datetime(df['date'], unit='ms')

--- a/data/websocket_poloniex.py
+++ b/data/websocket_poloniex.py
@@ -2,9 +2,12 @@ import websocket
 import json
 import pandas as pd
 from datetime import datetime
+import logging
 
 from config_live import data_settings_poloniex
 from api_service import send_request
+
+logger = logging.getLogger(__name__)
 
 class PoloniexWebsocketClient:
 
@@ -54,15 +57,15 @@ class PoloniexWebsocketClient:
 
     def run_bot(self, pair):
         ticker_data_list= self.pair_ticker_data_list_dictionary[pair]
-        df = self.createDataFrame(ticker_data_list=ticker_data_list)
+        df = self.create_dataframe(ticker_data_list=ticker_data_list)
         buy_or_sell_signal = self.get_buy_or_sell_signal(data=df)
-        print('buy signal for pair {}: {}'.format(pair, buy_or_sell_signal))
+        logger.debug('buy signal for pair {}: {}'.format(pair, buy_or_sell_signal))
 
         # for now the revenyou api accepts only buy signals!
         if buy_or_sell_signal == 'buy':
             send_request(pair=pair)
 
-    def createDataFrame(self, ticker_data_list):
+    def create_dataframe(self, ticker_data_list):
         df = pd.DataFrame(ticker_data_list, columns=['pair_id', 'close', 'low_ask', 'high_ask', 'percentage_change', 'volume', 
             'quote_volume', 'is_frozen', 'high', 'low', 'date'])
         df = df.set_index(['date'])

--- a/run_bot.sh
+++ b/run_bot.sh
@@ -10,7 +10,7 @@ MODE="$1"
 if [ "$MODE" == "test" ] ; then
   docker-compose -f docker/docker-compose-test.yml up --build
 elif [ "$MODE" == "live" ] ; then
-  docker-compose -f docker/docker-compose-live.yml up --build
+  docker-compose -f docker/docker-compose-live.yml up --build -d
 elif [ "$MODE" == "stop_live" ] ; then
   docker-compose -f docker/docker-compose-live.yml down
 else

--- a/run_live.py
+++ b/run_live.py
@@ -1,4 +1,6 @@
 import importlib
+import logging
+logging.basicConfig(level=logging.DEBUG)
 
 from config_live import datasource, bot_name
 from data.websocket_binance import BinanceWebsocketClient


### PR DESCRIPTION
This PR will add functionality for multipair trading in the live environment.

For Binance:
- subscribe to multiple pairs (streams) with one websocket connection
- when a message comes in store the ticker data in the pair_ticker_data_list dictionary
- run the bot for the pair that the ticker data belongs to

For Poloniex:
- subscribe to the ticker data stream with one websocket connection
- when a message comes in filter on the pairs you need and store the ticker data in the pair_ticker_data_list dictionary
- run the bot for the pair that the ticker data belongs to