### PR TITLE
Added specific version range for jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ empyrical==0.5.3
 numpy==1.18.2
 websocket-client==0.57.0
 mplfinance
+Jinja2>=2.10.1,<3.1


### PR DESCRIPTION
Due to changes in the latest released jinja2 the project is failing to run.
The following exception is thrown:

Attaching to docker_bot_1
bot_1  | Traceback (most recent call last):
bot_1  |   File "run_test.py", line 4, in <module>
bot_1  |     from youengine.helpers.analyze import analyze_mpl, analyze_bokeh
bot_1  |   File "/opt/bot/youengine/helpers/analyze.py", line 4, in <module>
bot_1  |     import bokeh.plotting
bot_1  |   File "/usr/local/lib/python3.8/site-packages/bokeh/plotting/__init__.py", line 67, in <module>
bot_1  |     from ..document import Document; Document
bot_1  |   File "/usr/local/lib/python3.8/site-packages/bokeh/document/__init__.py", line 35, in <module>
bot_1  |     from .document import DEFAULT_TITLE ; DEFAULT_TITLE
bot_1  |   File "/usr/local/lib/python3.8/site-packages/bokeh/document/document.py", line 49, in <module>
bot_1  |     from ..core.templates import FILE
bot_1  |   File "/usr/local/lib/python3.8/site-packages/bokeh/core/templates.py", line 42, in <module>
bot_1  |     from jinja2 import Environment, FileSystemLoader, Markup
bot_1  | ImportError: cannot import name 'Markup' from 'jinja2' (/usr/local/lib/python3.8/site-packages/jinja2/__init__.py)
docker_bot_1 exited with code 1
By adding a specific version range in requirements.txt for jinja2, the issue is fixed.

Jinja2>=2.10.1,<3.1